### PR TITLE
update to use catkin_virtualenv

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,21 @@
 cmake_minimum_required(VERSION 2.8.12)
 project(chainercv)
 
-find_package(catkin REQUIRED COMPONENTS catkin_pip)
+# Make sure to find-package `catkin_virtualenv`
+find_package(catkin REQUIRED catkin_virtualenv)
 
-# defining current package as a package that should be managed by pip (not catkin - even though we make it usable with workspaces)
-catkin_pip_package_virtualenv(${PROJECT_NAME})
-# CAREFUL : all projects for test here will share the same workspace. pip might have conflicts...
+# Must be called before catkin_generate_virtualenv
+catkin_package()
 
-# # We need to install the project pip dependencies in the devel workspace being created
-# catkin_pip_requirements(${CMAKE_CURRENT_SOURCE_DIR}/requirements.txt)
+# Generate the virtualenv, optionally with python 3 as the default interpreter:
+catkin_generate_virtualenv()
+# catkin_generate_virtualenv(PYTHON3)
+
+# Make sure your python executables are installed using `catkin_install_python`:
+catkin_install_python(
+  PROGRAMS
+  scripts/ssd_demo.py
+  DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
+
+install(FILES requirements.txt
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})

--- a/package.xml
+++ b/package.xml
@@ -3,14 +3,18 @@
   <name>chainercv</name>
   <version>0.0.1</version>
   <description>
-    ChainerCV with Catkin
+    ChainerCV ROS Interface
   </description>
-  <maintainer email="asmodehn@gmail.com">AlexV</maintainer>
+  <maintainer email="yuyuniitani@gmail.com">Yusuke Niitani</maintainer>
   <author>Yusuke Niitani</author>
   <license>MIT</license>
   <url type="repository">https://github.com/yuyu2172/chainercv-ros.git</url>
 
   <buildtool_depend>catkin</buildtool_depend>
-  <build_depend version_gte="0.1.16">catkin_pip</build_depend>
+  <build_depend>catkin_virtualenv</build_depend>
+
+  <export>
+    <pip_requirements>requirements.txt</pip_requirements>
+  </export>
 
 </package>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+chainercv>=0.8


### PR DESCRIPTION
As I commented on https://github.com/pyros-dev/catkin_pip/issues/109#issuecomment-367290971, chanier_virtualenv seems better in terms of our requirement